### PR TITLE
feat: Add C# support and improve query handling infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "transformers>=4.47.1",
     "tree-sitter==0.21.3",
     "tree-sitter-languages==1.10.2",
+    "tree-sitter-c-sharp",
     "tqdm",
 ]
 

--- a/src/llmap/queries/c_sharp/skeleton.scm
+++ b/src/llmap/queries/c_sharp/skeleton.scm
@@ -1,0 +1,30 @@
+; Using directives
+(using_directive) @using.directive
+
+; Classes
+(class_declaration
+  name: (identifier) @class.name) @class.declaration
+
+; Interfaces
+(interface_declaration
+  name: (identifier) @interface.name) @interface.declaration
+
+; Methods
+(method_declaration
+  name: (identifier) @method.name) @method.declaration
+
+; Fields
+(field_declaration
+  (variable_declaration
+    (variable_declarator
+      name: (identifier) @field.name))) @field.declaration
+
+; Properties
+(property_declaration
+  name: (identifier) @property.name) @property.declaration
+
+; Constructor
+(constructor_declaration) @constructor.declaration
+
+; Attributes
+(attribute_list) @annotation


### PR DESCRIPTION
This PR introduces C# language support and refactors the code parsing infrastructure:

1. **New Features**
   - Added C# parsing capability with a new Tree-sitter grammar dependency (`tree-sitter-c-sharp`)
   - Implemented C# skeleton query template capturing:
     - Class/interface declarations
     - Methods, fields, and properties
     - Constructors and attributes
     - Using imports (I think its valueable to keep the imports/usings - what do you think?)

2. **Improvements**
   - Refactored query loading mechanism to use a centralized language map:
     ```python
     QUERIES = {
         '.java': 'java',
         '.py': 'python',
         '.cs': 'c_sharp'
     }
     ```
   - Enhanced skeleton generation to include C# using directives
   - Improved language detection logic to be more maintainable

3. **Maintenance**
   - Fixed package inclusion configuration in pyproject.toml
   - Updated query path resolution to use dynamic path construction
   - Maintained backward compatibility with existing Java/Python support

The changes maintain existing functionality while expanding language support and creating a more scalable architecture for adding future language parsers. Query handling is now more consistent across supported languages, and the new C# support follows the same patterns used for Java and Python analysis.